### PR TITLE
Add config so that hive tables can ask to not fail when duplicate object keys are present

### DIFF
--- a/json-serde/src/main/java/org/openx/data/jsonserde/JsonSerDe.java
+++ b/json-serde/src/main/java/org/openx/data/jsonserde/JsonSerDe.java
@@ -77,9 +77,14 @@ public class JsonSerDe implements SerDe {
     private boolean lastOperationSerialize;
     long deserializedDataSize;
     long serializedDataSize;
+
     // if set, will ignore malformed JSON in deserialization
     boolean ignoreMalformedJson = false;
     public static final String PROP_IGNORE_MALFORMED_JSON = "ignore.malformed.json";
+
+    // Causes the JSON parser not to fail when duplicated object keys are encountered
+    boolean allowDuplicates = false;
+    public static final String PROP_ALLOW_DUPLICATE_KEYS = "allow.duplicate.json.keys";
     
    JsonStructOIOptions options;
 
@@ -141,6 +146,9 @@ public class JsonSerDe implements SerDe {
         // other configuration
         ignoreMalformedJson = Boolean.parseBoolean(tbl
                 .getProperty(PROP_IGNORE_MALFORMED_JSON, "false"));
+
+        allowDuplicates = Boolean.parseBoolean(tbl
+                .getProperty(PROP_ALLOW_DUPLICATE_KEYS, "false"));
         
     }
 
@@ -165,16 +173,16 @@ public class JsonSerDe implements SerDe {
             String txt = rowText.toString().trim();
             
             if(txt.startsWith("{")) {
-                jObj = new JSONObject(txt);
+                jObj = new JSONObject(txt, allowDuplicates);
             } else if (txt.startsWith("[")){
-                jObj = new JSONArray(txt);
+                jObj = new JSONArray(txt, allowDuplicates);
             }
         } catch (JSONException e) {
             // If row is not a JSON object, make the whole row NULL
             onMalformedJson("Row is not a valid JSON Object - JSONException: "
                     + e.getMessage());
             try {
-                jObj = new JSONObject("{}");
+                jObj = new JSONObject("{}", allowDuplicates);
             } catch (JSONException ex) {
                 onMalformedJson("Error parsing empty row. This should never happen.");
             }

--- a/json/src/main/java/org/openx/data/jsonserde/json/CDL.java
+++ b/json/src/main/java/org/openx/data/jsonserde/json/CDL.java
@@ -179,7 +179,7 @@ public class CDL {
      * @throws JSONException
      */
     public static JSONArray toJSONArray(String string) throws JSONException {
-        return toJSONArray(new JSONTokener(string));
+        return toJSONArray(new JSONTokener(string, false));
     }
 
     /**
@@ -203,7 +203,7 @@ public class CDL {
      */
     public static JSONArray toJSONArray(JSONArray names, String string)
             throws JSONException {
-        return toJSONArray(names, new JSONTokener(string));
+        return toJSONArray(names, new JSONTokener(string, false));
     }
 
     /**

--- a/json/src/main/java/org/openx/data/jsonserde/json/Cookie.java
+++ b/json/src/main/java/org/openx/data/jsonserde/json/Cookie.java
@@ -82,7 +82,7 @@ public class Cookie {
         String         name;
         JSONObject     jo = new JSONObject();
         Object         value;
-        JSONTokener x = new JSONTokener(string);
+        JSONTokener x = new JSONTokener(string, false);
         jo.put("name", x.nextTo('='));
         x.next('=');
         jo.put("value", x.nextTo(';'));

--- a/json/src/main/java/org/openx/data/jsonserde/json/CookieList.java
+++ b/json/src/main/java/org/openx/data/jsonserde/json/CookieList.java
@@ -48,7 +48,7 @@ public class CookieList {
      */
     public static JSONObject toJSONObject(String string) throws JSONException {
         JSONObject jo = new JSONObject();
-        JSONTokener x = new JSONTokener(string);
+        JSONTokener x = new JSONTokener(string, false);
         while (x.more()) {
             String name = Cookie.unescape(x.nextTo('='));
             x.next('=');

--- a/json/src/main/java/org/openx/data/jsonserde/json/HTTPTokener.java
+++ b/json/src/main/java/org/openx/data/jsonserde/json/HTTPTokener.java
@@ -37,7 +37,7 @@ public class HTTPTokener extends JSONTokener {
      * @param string A source string.
      */
     public HTTPTokener(String string) {
-        super(string);
+        super(string, false);
     }
 
 

--- a/json/src/main/java/org/openx/data/jsonserde/json/JSONArray.java
+++ b/json/src/main/java/org/openx/data/jsonserde/json/JSONArray.java
@@ -141,8 +141,8 @@ public class JSONArray {
      *  and ends with <code>]</code>&nbsp;<small>(right bracket)</small>.
      *  @throws JSONException If there is a syntax error.
      */
-    public JSONArray(String source) throws JSONException {
-        this(new JSONTokener(source));
+    public JSONArray(String source, boolean allowDuplicates) throws JSONException {
+        this(new JSONTokener(source, allowDuplicates));
     }
 
 

--- a/json/src/main/java/org/openx/data/jsonserde/json/JSONObject.java
+++ b/json/src/main/java/org/openx/data/jsonserde/json/JSONObject.java
@@ -172,7 +172,7 @@ public class JSONObject {
         this();
         for (int i = 0; i < names.length; i += 1) {
             try {
-                putOnce(names[i].toLowerCase(), jo.opt(names[i]));
+                putOnce(names[i].toLowerCase(), jo.opt(names[i]), false);
             } catch (JSONException ignore) {
             }
         }
@@ -215,7 +215,7 @@ public class JSONObject {
             } else if (c != ':') {
                 throw x.syntaxError("Expected a ':' after a key");
             }
-            putOnce(key, x.nextValue());
+            putOnce(key, x.nextValue(), x.isAllowDuplicates());
 
 // Pairs are separated by ','. We will also tolerate ';'.
 
@@ -315,8 +315,8 @@ public class JSONObject {
      * @exception JSONException If there is a syntax error in the source
      *  string or a duplicated key.
      */
-    public JSONObject(String source) throws JSONException {
-        this(new JSONTokener(source));
+    public JSONObject(String source, boolean allowDuplicates) throws JSONException {
+        this(new JSONTokener(source, allowDuplicates));
     }
 
 
@@ -1126,9 +1126,9 @@ public class JSONObject {
      * @return his.
      * @throws JSONException if the key is a duplicate
      */
-    public final JSONObject putOnce(String key, Object value) throws JSONException {
+    public final JSONObject putOnce(String key, Object value, boolean allowDuplicates) throws JSONException {
         if (key != null && value != null) {
-            if (opt(key) != null) {
+            if (!allowDuplicates && opt(key) != null) {
                 throw new JSONException("Duplicate key \"" + key + "\"");
             }
             put(key, value);

--- a/json/src/main/java/org/openx/data/jsonserde/json/JSONTokener.java
+++ b/json/src/main/java/org/openx/data/jsonserde/json/JSONTokener.java
@@ -47,6 +47,7 @@ public class JSONTokener {
     private char 	previous;
     private Reader 	reader;
     private boolean usePrevious;
+    private boolean allowDuplicates;
 
 
     /**
@@ -54,7 +55,7 @@ public class JSONTokener {
      *
      * @param reader     A reader.
      */
-    public JSONTokener(Reader reader) {
+    public JSONTokener(Reader reader, boolean allowDuplicates) {
         this.reader = reader.markSupported() ? 
         		reader : new BufferedReader(reader);
         this.eof = false;
@@ -63,6 +64,7 @@ public class JSONTokener {
         this.index = 0;
         this.character = 1;
         this.line = 1;
+        this.allowDuplicates = allowDuplicates;
     }
     
     
@@ -71,8 +73,8 @@ public class JSONTokener {
      * @param inputStream
      * @throws org.openx.data.jsonserde.json.JSONException
      */
-    public JSONTokener(InputStream inputStream) throws JSONException {
-        this(new InputStreamReader(inputStream));    	
+    public JSONTokener(InputStream inputStream, boolean allowDuplicates) throws JSONException {
+        this(new InputStreamReader(inputStream), allowDuplicates);
     }
 
 
@@ -81,10 +83,14 @@ public class JSONTokener {
      *
      * @param s     A source string.
      */
-    public JSONTokener(String s) {
-        this(new StringReader(s));
+    public JSONTokener(String s, boolean allowDuplicates) {
+        this(new StringReader(s), allowDuplicates);
     }
 
+
+    public boolean isAllowDuplicates() {
+        return allowDuplicates;
+    }
 
     /**
      * Back up one character. This provides a sort of lookahead capability,

--- a/json/src/main/java/org/openx/data/jsonserde/json/JSONWriter.java
+++ b/json/src/main/java/org/openx/data/jsonserde/json/JSONWriter.java
@@ -204,7 +204,7 @@ public class JSONWriter {
         }
         if (this.mode == 'k') {
             try {
-                stack[top - 1].putOnce(string, Boolean.TRUE);
+                stack[top - 1].putOnce(string, Boolean.TRUE, false);
                 if (this.comma) {
                     this.writer.write(',');
                 }

--- a/json/src/main/java/org/openx/data/jsonserde/json/XMLTokener.java
+++ b/json/src/main/java/org/openx/data/jsonserde/json/XMLTokener.java
@@ -52,7 +52,7 @@ public class XMLTokener extends JSONTokener {
      * @param s A source string.
      */
     public XMLTokener(String s) {
-        super(s);
+        super(s, false);
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.openx.data</groupId>
     <artifactId>json-serde-parent</artifactId>
-    <version>1.3.1-SNAPSHOT</version>
+    <version>1.3.1-MANGO</version>
     <packaging>pom</packaging>
 
     <name>openx-json-serde</name>


### PR DESCRIPTION
@mangohealth/owners 

Here is a first attempt at a mango-health pull request...

This should add an option that can be inserted into a hive SERDEPROPERTIES clause called "allow.duplicate.json.keys" in the same fashion as "ignore.malformed.json".  This will allow json serde to selectively not throw exceptions on a table-by-table level when it encounters multiple JSON object keys that are the same once forced to lowercase.
