### PR TITLE
Remove the hard crash for duplicate object keys

### DIFF
--- a/json/src/main/java/org/openx/data/jsonserde/json/JSONObject.java
+++ b/json/src/main/java/org/openx/data/jsonserde/json/JSONObject.java
@@ -1128,9 +1128,10 @@ public class JSONObject {
      */
     public final JSONObject putOnce(String key, Object value) throws JSONException {
         if (key != null && value != null) {
-            if (opt(key) != null) {
-                throw new JSONException("Duplicate key \"" + key + "\"");
-            }
+            // No great way to quickly get config for this and unfortunately a must have for us, so turning it off :-(
+//            if (opt(key) != null) {
+//                throw new JSONException("Duplicate key \"" + key + "\"");
+//            }
             put(key, value);
         }
         return this;


### PR DESCRIPTION
Value for the last key will just always win for now.  This was part of fast emergency response from a while back, so just formalizing this now before I pull from upstream and add new changes to support new features.
