### PR TITLE
Make prefix mappings and general type handling more robust

### DIFF
--- a/json-serde/src/main/java/org/openx/data/jsonserde/JsonSerDe.java
+++ b/json-serde/src/main/java/org/openx/data/jsonserde/JsonSerDe.java
@@ -184,18 +184,18 @@ public class JsonSerDe implements SerDe {
             String txt = rowText.toString().trim();
             
             if(txt.startsWith("{")) {
-                jObj = new JSONObject(txt, allowDuplicates);
+                jObj = new JSONObject(txt, allowDuplicates, "deserialize-base");
             } else if (txt.startsWith("[")){
                 jObj = new JSONArray(txt, allowDuplicates);
             }
         } catch (JSONException e) {
             // If row is not a JSON object, make the whole row NULL
             onMalformedJson("Row is not a valid JSON Object - JSONException: "
-                    + e.getMessage());
+                    + e.getMessage(), rowText.toString().trim());
             try {
-                jObj = new JSONObject("{}", allowDuplicates);
+                jObj = new JSONObject("{}", allowDuplicates, "malformed");
             } catch (JSONException ex) {
-                onMalformedJson("Error parsing empty row. This should never happen.");
+                onMalformedJson("Error parsing empty row. This should never happen.", "");
             }
         }
 	
@@ -268,7 +268,7 @@ public class JsonSerDe implements SerDe {
             return null;
         }
 
-        JSONObject result = new JSONObject();
+        JSONObject result = new JSONObject("serialize-parent");
         
         List<? extends StructField> fields = soi.getAllStructFieldRefs();
         
@@ -409,7 +409,7 @@ public class JsonSerDe implements SerDe {
     private JSONObject serializeMap(Object obj, MapObjectInspector moi) {
         if (obj==null) { return null; }
         
-        JSONObject jo = new JSONObject();  
+        JSONObject jo = new JSONObject("serialize-map");
         Map m = moi.getMap(obj);
         
         for(Object k : m.keySet()) {
@@ -424,9 +424,10 @@ public class JsonSerDe implements SerDe {
         return jo;
     }
     
-    public void onMalformedJson(String msg) throws SerDeException {
+    public void onMalformedJson(String msg, String input) throws SerDeException {
         if(ignoreMalformedJson) {
-            LOG.warn("Ignoring malformed JSON: " + msg);
+            System.err.println("Ignoring malformed JSON: " + msg);
+            System.err.println("Which had this as input: " + input);
         }  else {
             throw new SerDeException(msg);
         }

--- a/json-serde/src/main/java/org/openx/data/jsonserde/JsonSerDe.java
+++ b/json-serde/src/main/java/org/openx/data/jsonserde/JsonSerDe.java
@@ -90,7 +90,7 @@ public class JsonSerDe implements SerDe {
     public static final String PROP_UNMAPPED_ATTR_KEY = "unmapped.attr.key";
 
     // Allow first level object keys w/ a given prefix to get aggregated into a well formed table column
-    public static final String PROP_PREFIX_MAPPING_PREFIX = "unmapped.prefix.";
+    public static final String PROP_PREFIX_MAPPING_PREFIX = "prefix.for.";
 
    JsonStructOIOptions options;
 
@@ -480,8 +480,8 @@ public class JsonSerDe implements SerDe {
                 String configKey = (String) entry;
                 if (configKey.startsWith(PROP_PREFIX_MAPPING_PREFIX)) {
                     retVal.put(
-                        tbl.getProperty(configKey).toLowerCase(),
-                        configKey.substring(configSuffixLen)
+                        configKey.substring(configSuffixLen),
+                        tbl.getProperty(configKey).toLowerCase()
                     );
                 }
             }

--- a/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/JsonListObjectInspector.java
+++ b/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/JsonListObjectInspector.java
@@ -35,7 +35,8 @@ public class JsonListObjectInspector extends StandardListObjectInspector {
     if (data == null || JSONObject.NULL.equals(data)) {
       return null;
     }
-    JSONArray array = (JSONArray) data;
+
+    JSONArray array = safetyCheck(data);
     List al = new ArrayList(array.length());
     for(int i =0; i< array.length(); i++) {
 	al.add(getListElement(data,i));
@@ -48,7 +49,8 @@ public class JsonListObjectInspector extends StandardListObjectInspector {
     if (data == null) {
       return null;
     }
-    JSONArray array = (JSONArray) data;
+
+    JSONArray array = safetyCheck(data);
     try {
         Object obj =  array.get(index);
 	if(JSONObject.NULL == obj) {
@@ -66,8 +68,34 @@ public class JsonListObjectInspector extends StandardListObjectInspector {
     if (data == null) {
       return -1;
     }
-    JSONArray array = (JSONArray) data;
+
+    JSONArray array = safetyCheck(data);
     return array.length();
   }
+
+  private JSONArray safetyCheck(Object data) {
+    if(!(data instanceof JSONArray)) {
+      // Allow empty objects to get translated as empty lists if that's what we expected.
+      // Do this because when we fail to parse some JSON, it'll default to {} which will otherwise
+      // cause this to break.
+      if(data instanceof JSONObject) {
+        JSONObject obj = (JSONObject) data;
+        if(obj.length() == 0) {
+          return JSONArray.EMPTY_ARRAY;
+        }
+      }
+
+      // Try to make as helpful an error message as possible so user can debug the problem
+      String msg = "Could not cast to JSONArray:  [[" + data.getClass() + "]] => ";
+      if(data instanceof JSONObject) {
+        msg += "[[parent=" + ((JSONObject) data).getParent() + "]] ";
+      }
+      msg += data.toString();
+      throw new RuntimeException(msg);
+    }
+
+    return (JSONArray) data;
+  }
+
     
 }

--- a/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/JsonStructObjectInspector.java
+++ b/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/JsonStructObjectInspector.java
@@ -66,7 +66,7 @@ public class JsonStructObjectInspector extends StandardStructObjectInspector {
             // sometimes getting [] instead of {} for an empty field.
             // this line should help them
             if(ja.length() == 0 ) return null;
-            return getStructFieldDataFromList(ja.getAsArrayList(), fieldRef );
+            return getStructFieldDataFromList(ja.getAsList(), fieldRef );
         } else {
             throw new Error("Data is not JSONObject  but " + data.getClass().getCanonicalName() +
                     " with value " + data.toString()) ;

--- a/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/primitive/JavaStringDoubleObjectInspector.java
+++ b/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/primitive/JavaStringDoubleObjectInspector.java
@@ -36,7 +36,7 @@ public class JavaStringDoubleObjectInspector extends AbstractPrimitiveJavaObject
     @Override
     public double get(Object o) {
         if(ParsePrimitiveUtils.isString(o)) {
-           return Double.parseDouble(o.toString());
+           return ParsePrimitiveUtils.parseDouble(o.toString());
         } else {
           return (Double) o;
         }

--- a/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/primitive/JavaStringFloatObjectInspector.java
+++ b/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/primitive/JavaStringFloatObjectInspector.java
@@ -36,7 +36,7 @@ public class JavaStringFloatObjectInspector extends AbstractPrimitiveJavaObjectI
     @Override
     public float get(Object o) {
         if(ParsePrimitiveUtils.isString(o)) {
-          return Float.parseFloat(o.toString());
+          return ParsePrimitiveUtils.parseFloat(o.toString());
         } else {
           return (Float) o;
         }

--- a/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/primitive/ParsePrimitiveUtils.java
+++ b/json-serde/src/main/java/org/openx/data/jsonserde/objectinspector/primitive/ParsePrimitiveUtils.java
@@ -6,7 +6,9 @@
 package org.openx.data.jsonserde.objectinspector.primitive;
 
 import java.sql.Timestamp;
-import org.apache.hadoop.hive.serde2.io.TimestampWritable;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.openx.data.jsonserde.json.JSONObject;
 
 /**
@@ -14,6 +16,9 @@ import org.openx.data.jsonserde.json.JSONObject;
  * @author rcongiu
  */
 public class ParsePrimitiveUtils {
+
+    public static final Log LOG = LogFactory.getLog(ParsePrimitiveUtils.class);
+
     public static boolean isHex(String s) {
         return s.startsWith("0x") || s.startsWith("0X");
     }
@@ -22,32 +27,80 @@ public class ParsePrimitiveUtils {
         if (isHex(s)) {
             return Byte.parseByte(s.substring(2), 16);
         } else {
-            return Byte.parseByte(s);
+            return Byte.parseByte(stripDecimal(s));
         }
     }
 
     public static int parseInt(String s) {
-        if (isHex(s)) {
-            return Integer.parseInt(s.substring(2), 16);
-        } else {
-            return Integer.parseInt(s);
+        try {
+            if (isHex(s)) {
+                return Integer.parseInt(s.substring(2), 16);
+            } else {
+                return Integer.parseInt(stripDecimal(s));
+            }
+        }
+        catch(NumberFormatException ex) {
+            LOG.warn("Could not parse this as an int:  " + s);
+            return 0;
         }
     }
 
     public static short parseShort(String s) {
-        if (isHex(s)) {
-            return Short.parseShort(s.substring(2), 16);
-        } else {
-            return Short.parseShort(s);
+        try {
+            if (isHex(s)) {
+                return Short.parseShort(s.substring(2), 16);
+            } else {
+                return Short.parseShort(stripDecimal(s));
+            }
         }
+        catch(NumberFormatException ex) {
+            LOG.warn("Could not parse this as a short:  " + s);
+            return 0;
+        }
+
     }
 
     public static long parseLong(String s) {
-        if (isHex(s)) {
-            return Long.parseLong(s.substring(2), 16);
-        } else {
-            return Long.parseLong(s);
+        try {
+            if (isHex(s)) {
+                return Long.parseLong(s.substring(2), 16);
+            } else {
+                return Long.parseLong(stripDecimal(s));
+            }
         }
+        catch(NumberFormatException ex) {
+            LOG.warn("Could not parse this as a long:  " + s);
+            return 0;
+        }
+    }
+
+    public static float parseFloat(String s) {
+        try {
+            return Float.parseFloat(s);
+        }
+        catch(NumberFormatException ex) {
+            LOG.warn("Could not parse this as a float:  " + s);
+            return 0;
+        }
+    }
+
+    public static double parseDouble(String s) {
+        try {
+            return Double.parseDouble(s);
+        }
+        catch(NumberFormatException ex) {
+            LOG.warn("Could not parse this as a double:  " + s);
+            return 0;
+        }
+    }
+
+    public static String stripDecimal(String s) {
+        int index = s.indexOf('.');
+        if(index > 0) {
+            return s.substring(0, index);
+        }
+
+        return s;
     }
 
     public static Timestamp parseTimestamp(String s) {

--- a/json-serde/src/test/java/org/openx/data/jsonserde/JsonSerDeTest.java
+++ b/json-serde/src/test/java/org/openx/data/jsonserde/JsonSerDeTest.java
@@ -332,7 +332,7 @@ public class JsonSerDeTest {
 
         Object result = instance.serialize(row, soi);
 
-        JSONObject res = new JSONObject(result.toString());
+        JSONObject res = new JSONObject(result.toString(), false, "test");
         assertEquals(res.getString("atext"), row.get(0));
 
         assertEquals(res.get("anumber"), row.get(1));

--- a/json-serde/src/test/java/org/openx/data/jsonserde/klarna/UnmappedPrefixTest.kt
+++ b/json-serde/src/test/java/org/openx/data/jsonserde/klarna/UnmappedPrefixTest.kt
@@ -33,7 +33,7 @@ class UnmappedPrefixTest {
               listed2 INT,
               a MAP<STRING, INT>,
               b MAP<STRING, FLOAT>,
-              c map<string, string>,
+              c map<STRING, STRING>,
               d MAP<STRING, ARRAY<INT>>,
               e MAP<STRING, MAP<STRING, INT>>,
               f MAP<STRING, BOOLEAN>,
@@ -42,18 +42,20 @@ class UnmappedPrefixTest {
                 h1:STRING,
                 h2:INT
               >>,
+              a2 MAP<STRING, STRING>,
               unmapped_cols MAP<STRING, STRING>
             )
             ROW FORMAT SERDE 'org.openx.data.jsonserde.JsonSerDe'
             WITH SERDEPROPERTIES (
-              "unmapped.prefix.a_" = "a",
-              "unmapped.prefix.b_" = "b",
-              "unmapped.prefix.c_" = "c",
-              "unmapped.prefix.d_" = "d",
-              "unmapped.prefix.e_" = "e",
-              "unmapped.prefix.f_" = "f",
-              "unmapped.prefix.g_" = "g",
-              "unmapped.prefix.h_" = "h",
+              "prefix.for.a" = "a_",
+              "prefix.for.b" = "b_",
+              "prefix.for.c" = "c_",
+              "prefix.for.d" = "d_",
+              "prefix.for.e" = "e_",
+              "prefix.for.f" = "f_",
+              "prefix.for.g" = "g_",
+              "prefix.for.h" = "h_",
+              "prefix.for.a2" = "a_",
               "unmapped.attr.key" = "unmapped_cols"
             )
             LOCATION '${tmpDir.root.absolutePath}';
@@ -67,17 +69,19 @@ class UnmappedPrefixTest {
         Assert.assertEquals(1, results.size)
         println(results.first())
         val cols = results.first().split("\t")
-        Assert.assertEquals("1", cols[0])
-        Assert.assertEquals("2", cols[1])
-        Assert.assertEquals("""{"a_456":2,"a_123":1,"a_789":3}""", cols[2])
-        Assert.assertEquals("""{"b_123":1.1}""", cols[3])
-        Assert.assertEquals("""{"c_123":"hello"}""", cols[4])
-        Assert.assertEquals("""{"d_123":[1,2,3]}""", cols[5])
-        Assert.assertEquals("""{"e_123":{"b":2,"a":1}}""", cols[6])
-        Assert.assertEquals("""{"f_123":true}""", cols[7])
-        Assert.assertEquals("""{"g_123":null}""", cols[8])
-        Assert.assertEquals("""{"h_123":{"h1":"abc","h2":1}}""", cols[9])
-        Assert.assertEquals("""{"bob":"123","nancy":"\"hello\""}""", cols[10])
+        Assert.assertEquals("regular col 1", "1", cols[0])
+        Assert.assertEquals("regular col 2", "2", cols[1])
+        Assert.assertEquals("int collecting", """{"a_456":2,"a_123":1,"a_789":3}""", cols[2])
+        Assert.assertEquals("float collecting", """{"b_123":1.1}""", cols[3])
+        Assert.assertEquals("string collecting", """{"c_123":"hello"}""", cols[4])
+        Assert.assertEquals("array<int> collecting", """{"d_123":[1,2,3]}""", cols[5])
+        Assert.assertEquals("map<string,int> collecting", """{"e_123":{"b":2,"a":1}}""", cols[6])
+        Assert.assertEquals("boolean collecting", """{"f_123":true}""", cols[7])
+        Assert.assertEquals("null collecting", """{"g_123":null}""", cols[8])
+        Assert.assertEquals("struct collecting", """{"h_123":{"h1":"abc","h2":1}}""", cols[9])
+        Assert.assertEquals("mapping the same prefix twice", """{"a_456":"2","a_123":"1","a_789":"3"}""", cols[10])
+        Assert.assertEquals("unmapped entries still works", """{"bob":"123","nancy":"\"hello\""}""", cols[11])
+
     }
 
 }

--- a/json/src/main/java/org/openx/data/jsonserde/json/Cookie.java
+++ b/json/src/main/java/org/openx/data/jsonserde/json/Cookie.java
@@ -80,7 +80,7 @@ public class Cookie {
      */
     public static JSONObject toJSONObject(String string) throws JSONException {
         String         name;
-        JSONObject     jo = new JSONObject();
+        JSONObject     jo = new JSONObject("cookie");
         Object         value;
         JSONTokener x = new JSONTokener(string, false);
         jo.put("name", x.nextTo('='));

--- a/json/src/main/java/org/openx/data/jsonserde/json/CookieList.java
+++ b/json/src/main/java/org/openx/data/jsonserde/json/CookieList.java
@@ -47,7 +47,7 @@ public class CookieList {
      * @throws JSONException
      */
     public static JSONObject toJSONObject(String string) throws JSONException {
-        JSONObject jo = new JSONObject();
+        JSONObject jo = new JSONObject("cookie-list");
         JSONTokener x = new JSONTokener(string, false);
         while (x.more()) {
             String name = Cookie.unescape(x.nextTo('='));

--- a/json/src/main/java/org/openx/data/jsonserde/json/HTTP.java
+++ b/json/src/main/java/org/openx/data/jsonserde/json/HTTP.java
@@ -69,7 +69,7 @@ public class HTTP {
      * @throws JSONException
      */
     public static JSONObject toJSONObject(String string) throws JSONException {
-        JSONObject     jo = new JSONObject();
+        JSONObject     jo = new JSONObject("http");
         HTTPTokener    x = new HTTPTokener(string);
         String         token;
 

--- a/json/src/main/java/org/openx/data/jsonserde/json/JSONArray.java
+++ b/json/src/main/java/org/openx/data/jsonserde/json/JSONArray.java
@@ -114,7 +114,7 @@ public class JSONArray {
 	                this.myArrayList.add(JSONObject.NULL);
 	            } else {
 	                x.back();
-	                this.myArrayList.add(x.nextValue(this.toString()));
+	                this.myArrayList.add(x.nextValue("array"));
 	            }
 	            switch (x.nextClean()) {
 	            case ';':

--- a/json/src/main/java/org/openx/data/jsonserde/json/JSONArray.java
+++ b/json/src/main/java/org/openx/data/jsonserde/json/JSONArray.java
@@ -27,10 +27,7 @@ SOFTWARE.
 import java.io.IOException;
 import java.io.Writer;
 import java.lang.reflect.Array;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.Map;
+import java.util.*;
 
 /**
  * A JSONArray is an ordered sequence of values. Its external text form is a
@@ -82,11 +79,14 @@ import java.util.Map;
  */
 public class JSONArray {
 
+    public static JSONArray EMPTY_ARRAY = new JSONArray() {{
+        this.myArrayList = Collections.unmodifiableList(new ArrayList());
+    }};
 
     /**
      * The arrayList where the JSONArray's properties are kept.
      */
-    private ArrayList myArrayList;
+    protected List myArrayList;
 
 
     /**
@@ -114,7 +114,7 @@ public class JSONArray {
 	                this.myArrayList.add(JSONObject.NULL);
 	            } else {
 	                x.back();
-	                this.myArrayList.add(x.nextValue());
+	                this.myArrayList.add(x.nextValue(this.toString()));
 	            }
 	            switch (x.nextClean()) {
 	            case ';':
@@ -629,7 +629,7 @@ public class JSONArray {
      * @return      this.
      */
     public JSONArray put(Map value) {
-        put(new JSONObject(value));
+        put(new JSONObject(value, "array"));
         return this;
     }
 
@@ -733,7 +733,7 @@ public class JSONArray {
      *  an invalid number.
      */
     public JSONArray put(int index, Map value) throws JSONException {
-        put(index, new JSONObject(value));
+        put(index, new JSONObject(value, "array"));
         return this;
     }
 
@@ -793,7 +793,7 @@ public class JSONArray {
         if (names == null || names.length() == 0 || length() == 0) {
             return null;
         }
-        JSONObject jo = new JSONObject();
+        JSONObject jo = new JSONObject(this,"array");
         for (int i = 0; i < names.length(); i += 1) {
             jo.put(names.getString(i), this.opt(i));
         }
@@ -918,7 +918,7 @@ public class JSONArray {
         }
     }
 
-    public ArrayList getAsArrayList() {
+    public List getAsList() {
         return myArrayList;
     }
     

--- a/json/src/main/java/org/openx/data/jsonserde/json/JSONML.java
+++ b/json/src/main/java/org/openx/data/jsonserde/json/JSONML.java
@@ -130,7 +130,7 @@ public class JSONML {
 		        	}
 		        	tagName = (String)token;
 		            newja = new JSONArray();		
-		            newjo = new JSONObject();
+		            newjo = new JSONObject("ml");
 		        	if (arrayForm) {
 			            newja.put(tagName);
 			            if (ja != null) {

--- a/json/src/main/java/org/openx/data/jsonserde/json/JSONTokener.java
+++ b/json/src/main/java/org/openx/data/jsonserde/json/JSONTokener.java
@@ -367,7 +367,7 @@ public class JSONTokener {
      *
      * @return An object.
      */
-    public Object nextValue() throws JSONException {
+    public Object nextValue(String parent) throws JSONException {
         char c = nextClean();
         String string;
 
@@ -377,7 +377,7 @@ public class JSONTokener {
                 return nextString(c);
             case '{':
                 back();
-                return new JSONObject(this);
+                return new JSONObject(this, parent);
             case '[':
                 back();
                 return new JSONArray(this);

--- a/json/src/main/java/org/openx/data/jsonserde/json/JSONWriter.java
+++ b/json/src/main/java/org/openx/data/jsonserde/json/JSONWriter.java
@@ -236,7 +236,7 @@ public class JSONWriter {
         }
         if (this.mode == 'o' || this.mode == 'a') {
             this.append("{");
-            this.push(new JSONObject());
+            this.push(new JSONObject("json-writer"));
             this.comma = false;
             return this;
         }

--- a/json/src/main/java/org/openx/data/jsonserde/json/XML.java
+++ b/json/src/main/java/org/openx/data/jsonserde/json/XML.java
@@ -213,7 +213,7 @@ public class XML {
         } else {
             tagName = (String)token;
             token = null;
-            jsonobject = new JSONObject();
+            jsonobject = new JSONObject("xml");
             for (;;) {
                 if (token == null) {
                     token = x.nextToken();
@@ -363,7 +363,7 @@ public class XML {
      * @throws JSONException
      */
     public static JSONObject toJSONObject(String string) throws JSONException {
-        JSONObject jo = new JSONObject();
+        JSONObject jo = new JSONObject("xml");
         XMLTokener x = new XMLTokener(string);
         while (x.more() && x.skipPast("<")) {
             parse(x, jo, null);


### PR DESCRIPTION
This all comes after the full integration verification and is added on top of this PR:  https://github.com/mangohealth/Hive-JSON-Serde/pull/4

Note that I've had to invert the prefix mappings from something like `"unmapped.prefix.point_" = "points"` to instead use something like this `"prefix.for.points" = "point_"`.  This is because we had a need for multiple columns to source the same prefix to different sets of structural interpretations.  This PR should fix that mistaken design assumption!  I've changed the config entry prefix to make it easier to know that things have changed and to make it a bit clearer what that config is actually doing.

I've also added a 'parent' member to JSONObject to make it a bit easier to debug problems since we can now include that bit of context in exception messages.  For now, I've only added this for a situation where I actually had a problem to debug, but having the basis in place makes it easy to add more, better messaging when necessary.  Adding context to JSONArray in the future would be just as helpful!

I've also made it so that when taking the size of an array, it will interpret the size to be zero if for some reason you have an empty JSON object instead (i.e., {}).  This is why we have better debug messages.  Yay!  This apparently happens when there's a JSON parsing error and you have ignore malformed turned on as you will _always_ get {} as a result before it continues to process.  This obviously causes problems if you've told the schema to expect an array in that spot.

I've also made all numeric primitive parsers more forgiving.  This includes:  
1. Strip any decimal portions before parsing int/short/long (it would have failed for `Integer.parse("1.234")` before, for instance)
2. For all numeric types, return a typed zero if you can't parse the value at all (e.g., `parseInteger('banana') => 0`).  This means single, funny numeric columns will no longer cause the entire pipeline to fail and will instead serve back semi-sensible data.  This may not work for all situations, but we can modify to better fit in the future.
