### PR TITLE
Migrate to hive 2

### DIFF
--- a/json-serde/pom.xml
+++ b/json-serde/pom.xml
@@ -14,6 +14,10 @@
 
     <name>json-serde-main</name>
 
+    <properties>
+        <kotlin.version>1.1.61</kotlin.version>
+    </properties>
+
 
     <build>
         <!-- wagon-ssh-external extension is necessary for deploying with scpexe -->
@@ -28,20 +32,23 @@
             <plugin>
                 <artifactId>kotlin-maven-plugin</artifactId>
                 <groupId>org.jetbrains.kotlin</groupId>
-                <version>1.0.1</version>
+                <version>${kotlin.version}</version>
 
-                <configuration/>
+                <configuration>
+                    <jvmTarget>1.8</jvmTarget>
+                </configuration>
+
                 <executions>
                     <execution>
                         <id>compile</id>
-                        <phase>process-sources</phase>
+                        <phase>compile</phase>
                         <goals>
                             <goal>compile</goal>
                         </goals>
                     </execution>
                     <execution>
                         <id>test-compile</id>
-                        <phase>process-test-sources</phase>
+                        <phase>test-compile</phase>
                         <goals>
                             <goal>test-compile</goal>
                         </goals>
@@ -89,6 +96,34 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <phase>none</phase>
+                    </execution>
+                    <execution>
+                        <id>default-testCompile</id>
+                        <phase>none</phase>
+                    </execution>
+                    <execution>
+                        <id>compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>testCompile</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
 
         </plugins>
     </build>
@@ -131,15 +166,35 @@
 
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-stdlib</artifactId>
-            <version>1.0.1</version>
+            <artifactId>kotlin-stdlib-jre8</artifactId>
+            <version>${kotlin.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>com.klarna</groupId>
             <artifactId>hiverunner</artifactId>
-            <version>2.6.0</version>
+            <version>4.0.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.codehaus.jackson</groupId>
+            <artifactId>jackson-core-asl</artifactId>
+            <version>1.9.2</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-kotlin</artifactId>
+            <version>2.8.7</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-test</artifactId>
+            <version>${kotlin.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/json-serde/src/main/java/org/openx/data/jsonserde/JsonSerDe.java
+++ b/json-serde/src/main/java/org/openx/data/jsonserde/JsonSerDe.java
@@ -20,7 +20,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import org.apache.hadoop.hive.serde2.SerDe;
+import org.apache.hadoop.hive.serde2.AbstractSerDe;
 import org.apache.hadoop.hive.serde2.SerDeException;
 import org.apache.hadoop.hive.serde2.objectinspector.*;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
@@ -61,7 +61,7 @@ import org.apache.hadoop.hive.serde2.typeinfo.PrimitiveTypeInfo;
  * 
  * @author rcongiu
  */
-public class JsonSerDe implements SerDe {
+public class JsonSerDe extends AbstractSerDe {
 
     public static final Log LOG = LogFactory.getLog(JsonSerDe.class);
     List<String> columnNames;

--- a/json-serde/src/test/java/org/openx/data/jsonserde/klarna/JsonKeyReplacementsTest.kt
+++ b/json-serde/src/test/java/org/openx/data/jsonserde/klarna/JsonKeyReplacementsTest.kt
@@ -56,14 +56,6 @@ class JsonKeyReplacementsTest : TestBase() {
             cols[1]
         )
         assertEquals("troxy matches", "abc", cols[2])
-
-        // TODO Orig junk
-//        assertEquals("1", cols[0])
-//        assertEquals(
-//            """[{"shoop":{"foot":{"testme":123}}},{"shoop":{"foot":{"testme":456}}}]""",
-//            cols[1]
-//        )
-//        assertEquals("abc", cols[2])
     }
 
     @Test
@@ -105,14 +97,6 @@ class JsonKeyReplacementsTest : TestBase() {
             cols[1]
         )
         assertEquals("troxy matches", "abc", cols[2])
-
-        // TODO Orig junk
-//        assertEquals("1", cols[0])
-//        assertEquals(
-//            """[{"shoop":{"foot":{"noot":123}}},{"shoop":{"foot":{"noot":456}}}]""",
-//            cols[1]
-//        )
-//        assertEquals("abc", cols[2])
     }
 
     @Test
@@ -154,13 +138,6 @@ class JsonKeyReplacementsTest : TestBase() {
             ),
             cols[1]
         )
-
-        // TODO Orig junk
-//        assertEquals("1", cols[0])
-//        assertEquals(
-//            """{"a_2":{"a_child":{"notouch":"def","testme":456}},"a_1":{"a_child":{"notouch":"abc","testme":123}}}""",
-//            cols[1]
-//        )
     }
 
     @Test
@@ -205,13 +182,6 @@ class JsonKeyReplacementsTest : TestBase() {
             ),
             cols[1]
         )
-
-        // TODO Orig junk
-//        assertEquals("1", cols[0])
-//        assertEquals(
-//            """{"a_2":{"a_child":{"notouch":"def","testme2":456}},"a_1":{"a_child":{"notouch":"abc","testme2":123}}}""",
-//            cols[1]
-//        )
     }
 
 }

--- a/json-serde/src/test/java/org/openx/data/jsonserde/klarna/TestBase.kt
+++ b/json-serde/src/test/java/org/openx/data/jsonserde/klarna/TestBase.kt
@@ -1,0 +1,74 @@
+package org.openx.data.jsonserde.klarna
+
+import com.fasterxml.jackson.core.JsonParseException
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.MapperFeature
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.klarna.hiverunner.HiveShell
+import com.klarna.hiverunner.StandaloneHiveRunner
+import org.junit.Assert
+import org.junit.runner.RunWith
+
+@RunWith(StandaloneHiveRunner::class)
+abstract class TestBase {
+
+    abstract var hiveShell:HiveShell?
+
+    companion object {
+        val JSON_MAPPER = jacksonObjectMapper()
+
+        init {
+            JSON_MAPPER.configure(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES, true);
+            JSON_MAPPER.configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES, true);
+        }
+    }
+
+    fun execute(str:String) {
+        hiveShell!!.execute(str)
+    }
+
+    fun query(queryStr:String):List<String> {
+        return hiveShell!!.executeQuery(queryStr)
+    }
+
+    fun queryOne(queryStr:String):String {
+        println(queryStr)
+        val results = query(queryStr)
+        Assert.assertNotNull("Hive should not provide a null response!", results)
+        Assert.assertEquals("Expected exactly 1 result!", 1, results.size)
+        return results.first()
+    }
+
+    fun queryForRowJSON(queryStr:String):List<Any> {
+        return queryOne(queryStr).split("\t").map {
+            try {
+                JSON_MAPPER.readValue<Any>(it)
+            }
+            catch(ex:JsonParseException) {
+                // It may be the case that not all cols are json, so tread lightly
+                it
+            }
+        }
+    }
+
+    inline fun <reified T : Any> queryForJSON(queryStr:String):T {
+        return JSON_MAPPER.readValue(queryOne(queryStr))
+    }
+
+    /**
+     * Parses Hive output as JSON to avoid having test expectation issues w/ Map key sorts!
+     */
+    inline fun <reified T : Any> queryForManyJSON(queryStr:String):List<T?> {
+        val results = query(queryStr)
+        return results.map {
+            if(it.equals("NULL", ignoreCase = true)) {
+                null
+            }
+            else {
+                JSON_MAPPER.readValue<T>(it)
+            }
+        }
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -51,8 +51,8 @@
                 <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
                 <serde.shim>json-serde-cdh5-shim</serde.shim>
                 <cdh.version>${cdh5.version}</cdh.version>
-                <cdh.hive.version>1.0.0</cdh.hive.version>
-                <cdh.hadoop.version>2.6.0</cdh.hadoop.version>
+                <cdh.hive.version>2.3.3</cdh.hive.version>
+                <cdh.hadoop.version>2.8.4</cdh.hadoop.version>
                 <cdh.shim>cdh5</cdh.shim>
             </properties>
         </profile>


### PR DESCRIPTION
This does a few things:

1. Brings in an old change we had pending to fail gracefully when we don't get an expected JSON Array (as we already did for JSON Objects) w/ a log warning rather than a hard exception
1. Re-work klarna tests to be a bit easier to work w/ + more tests
1. Migrate all this to a Hive 2.3.3 stack in order to mirror latest EMR-5 platform.  Notably, this involves changing the SerDe interface to instead use the AbstractSerDe base class.

All tests pass, should be good to go.